### PR TITLE
Fix a ConcurrentModificationException inside of MBeanExporter

### DIFF
--- a/src/main/java/org/weakref/jmx/MBeanExporter.java
+++ b/src/main/java/org/weakref/jmx/MBeanExporter.java
@@ -104,7 +104,8 @@ public class MBeanExporter
     public void unexportAll()
     {
         synchronized(exportedObjectNames) {
-            for (String objectName : exportedObjectNames) {
+            // Copy exportedObjectNames since unexport modifies it, causing ConcurrentModificationException
+            for (String objectName : new HashSet<String>(exportedObjectNames)) {
                 unexport(objectName);
             }
             exportedObjectNames.clear();


### PR DESCRIPTION
Modifying a HashSet while iterating over it causes a ConcurrentModificationException.

This introduces a copy operation which ensures that the iterator is happy.

Henning suggested making the entire set a ConcurrentHashSet of some sort instead.  I wanted to make the minimal change, but if you think that is a better solution feel free to do whatever you like.
