### PR TITLE
Fix corrupted state in MBeanExporter with duplicate keys

### DIFF
--- a/src/main/java/org/weakref/jmx/MBeanExporter.java
+++ b/src/main/java/org/weakref/jmx/MBeanExporter.java
@@ -27,6 +27,7 @@ import javax.management.MBeanServer;
 import javax.management.MalformedObjectNameException;
 import javax.management.NotCompliantMBeanException;
 import javax.management.ObjectName;
+
 import java.lang.management.ManagementFactory;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -48,7 +49,7 @@ public class MBeanExporter
     public MBeanExporter(MBeanServer server)
     {
         this.server = server;
-        exportedObjects = new MapMaker().weakKeys().weakValues().makeMap();
+        exportedObjects = new MapMaker().weakValues().makeMap();
     }
 
     public void export(String name, Object object)
@@ -71,8 +72,11 @@ public class MBeanExporter
             MBean mbean = builder.build();
 
             synchronized(exportedObjects) {
-                exportedObjects.put(objectName, object);
+                if(exportedObjects.containsKey(objectName)) {
+                    throw new JmxException(Reason.INSTANCE_ALREADY_EXISTS, "key already exported");
+                }
                 server.registerMBean(mbean, objectName);
+                exportedObjects.put(objectName, object);
             }
         }
         catch (InstanceAlreadyExistsException e) {

--- a/src/test/java/org/weakref/jmx/TestExporter.java
+++ b/src/test/java/org/weakref/jmx/TestExporter.java
@@ -17,6 +17,7 @@
 package org.weakref.jmx;
 
 import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
 import org.weakref.jmx.testing.TestingMBeanServer;
 
 import javax.management.AttributeNotFoundException;
@@ -28,10 +29,12 @@ import javax.management.MBeanServer;
 import javax.management.MalformedObjectNameException;
 import javax.management.ObjectName;
 import javax.management.ReflectionException;
+
 import java.io.IOException;
 import java.rmi.NotBoundException;
 import java.util.ArrayList;
 
+import static org.testng.Assert.assertEquals;
 import static org.weakref.jmx.Util.getUniqueObjectName;
 
 public class TestExporter extends AbstractMbeanTest<TestExporter.NamedObject>
@@ -108,6 +111,21 @@ public class TestExporter extends AbstractMbeanTest<TestExporter.NamedObject>
         for (NamedObject namedObject : objects) {
             exporter.export(namedObject.objectName.getCanonicalName(), namedObject.object);
         }
+    }
+
+    @Test
+    void testDuplicateKey()
+    {
+        MBeanExporter exporter = new MBeanExporter(server);
+
+        exporter.export(new String("test:test=test"), new SimpleObject());
+        try {
+            exporter.export(new String("test:test=test"), new SimpleObject());
+        }
+        catch(JmxException e) {
+            // do nothing
+        }
+        assertEquals(exporter.getExportedObjects().size(), 1);
     }
 
 //    @AfterTest


### PR DESCRIPTION
- Change exportedObjects to not use weakKeys(), otherwise key comparison is done based on identity (==)
- Change export(), so that it does not insert into exportedObjects, if registerMBean fails
