### PR TITLE
Update Maven shade plugin to 3.2.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -113,7 +113,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-shade-plugin</artifactId>
-                <version>2.3</version>
+                <version>3.2.1</version>
                 <executions>
                     <execution>
                         <phase>package</phase>


### PR DESCRIPTION
The older version generates bytecode that is not valid for Java 9+
and results in IncompatibleClassChangeError at runtime.