### PR TITLE
Retain and expose managed export metadata

### DIFF
--- a/src/main/java/org/weakref/jmx/MBeanExporter.java
+++ b/src/main/java/org/weakref/jmx/MBeanExporter.java
@@ -45,7 +45,7 @@ public class MBeanExporter
     private final MBeanServer server;
     private final Map<ObjectName, Object> exportedObjects;
     private final ObjectNameGenerator objectNameGenerator;
-    private final Map<ObjectName, ManagedClass> exportedManagedClasses = new ConcurrentHashMap<>();
+    private final Map<ObjectName, ManagedObjectExport> exportedManagedObjectExports = new ConcurrentHashMap<>();
 
     public MBeanExporter(MBeanServer server)
     {
@@ -74,8 +74,9 @@ public class MBeanExporter
     public MBeanExport exportWithGeneratedName(Object object)
     {
         requireNonNull(object, "object is null");
-        ObjectName objectName = createObjectName(objectNameGenerator.generatedNameOf(object.getClass()));
-        export(objectName, object);
+        Class<?> type = object.getClass();
+        ObjectName objectName = createObjectName(objectNameGenerator.generatedNameOf(type));
+        export(objectName, object, Optional.of(type), Optional.empty(), ImmutableMap.of());
         return new MBeanExport(objectName, () -> unexport(objectName));
     }
 
@@ -84,7 +85,16 @@ public class MBeanExporter
         requireNonNull(object, "object is null");
         requireNonNull(type, "type is null");
         ObjectName objectName = createObjectName(objectNameGenerator.generatedNameOf(type));
-        export(objectName, object);
+        export(objectName, object, Optional.of(type), Optional.empty(), ImmutableMap.of());
+        return new MBeanExport(objectName, () -> unexport(objectName));
+    }
+
+    public MBeanExport exportWithGeneratedName(ObjectName objectName, Object object, Class<?> type)
+    {
+        requireNonNull(objectName, "objectName is null");
+        requireNonNull(object, "object is null");
+        requireNonNull(type, "type is null");
+        export(objectName, object, Optional.of(type), Optional.empty(), ImmutableMap.of());
         return new MBeanExport(objectName, () -> unexport(objectName));
     }
 
@@ -94,7 +104,17 @@ public class MBeanExporter
         requireNonNull(type, "type is null");
         requireNonNull(name, "name is null");
         ObjectName objectName = createObjectName(objectNameGenerator.generatedNameOf(type, name));
-        export(objectName, object);
+        export(objectName, object, Optional.of(type), Optional.of(name), ImmutableMap.of());
+        return new MBeanExport(objectName, () -> unexport(objectName));
+    }
+
+    public MBeanExport exportWithGeneratedName(ObjectName objectName, Object object, Class<?> type, String name)
+    {
+        requireNonNull(objectName, "objectName is null");
+        requireNonNull(object, "object is null");
+        requireNonNull(type, "type is null");
+        requireNonNull(name, "name is null");
+        export(objectName, object, Optional.of(type), Optional.of(name), ImmutableMap.of());
         return new MBeanExport(objectName, () -> unexport(objectName));
     }
 
@@ -104,7 +124,7 @@ public class MBeanExporter
         requireNonNull(type, "type is null");
         requireNonNull(properties, "properties is null");
         ObjectName objectName = createObjectName(objectNameGenerator.generatedNameOf(type, properties));
-        export(objectName, object);
+        export(objectName, object, Optional.of(type), Optional.empty(), properties);
         return new MBeanExport(objectName, () -> unexport(objectName));
     }
 
@@ -113,8 +133,34 @@ public class MBeanExporter
         export(createObjectName(name), object);
     }
 
+    public void export(String name, Object object, Class<?> type)
+    {
+        export(createObjectName(name), object, type);
+    }
+
     public void export(ObjectName objectName, Object object)
     {
+        export(objectName, object, Optional.empty(), Optional.empty(), ImmutableMap.of());
+    }
+
+    public void export(ObjectName objectName, Object object, Class<?> type)
+    {
+        requireNonNull(type, "type is null");
+        export(objectName, object, Optional.of(type), Optional.empty(), ImmutableMap.of());
+    }
+
+    private void export(
+            ObjectName objectName,
+            Object object,
+            Optional<Class<?>> exportedType,
+            Optional<String> originalName,
+            Map<String, String> originalProperties)
+    {
+        requireNonNull(objectName, "objectName is null");
+        requireNonNull(object, "object is null");
+        requireNonNull(exportedType, "exportedType is null");
+        requireNonNull(originalName, "originalName is null");
+        requireNonNull(originalProperties, "originalProperties is null");
         try {
             MBeanBuilder builder = new MBeanBuilder(object);
             MBean mbean = builder.build();
@@ -127,7 +173,8 @@ public class MBeanExporter
                 exportedObjects.put(objectName, object);
             }
 
-            exportedManagedClasses.put(objectName, ManagedClass.fromExportedObject(object));
+            ManagedClass managedClass = ManagedClass.fromExportedObject(object);
+            exportedManagedObjectExports.put(objectName, new ManagedObjectExport(objectName, exportedType, originalName, originalProperties, managedClass));
         }
         catch (InstanceAlreadyExistsException e) {
             throw new JmxException(Reason.INSTANCE_ALREADY_EXISTS, e.getMessage());
@@ -174,7 +221,7 @@ public class MBeanExporter
                 exportedObjects.remove(objectName);
             }
 
-            exportedManagedClasses.remove(objectName);
+            exportedManagedObjectExports.remove(objectName);
         }
         catch (MBeanRegistrationException e) {
             throw new JmxException(Reason.MBEAN_REGISTRATION, e.getMessage(), e.getCause());
@@ -220,7 +267,7 @@ public class MBeanExporter
 
             exportedObjects.keySet().removeAll(toRemove);
 
-            exportedManagedClasses.keySet().removeAll(toRemove);
+            exportedManagedObjectExports.keySet().removeAll(toRemove);
         }
 
         return errors;
@@ -240,10 +287,18 @@ public class MBeanExporter
     public Map<String, ManagedClass> getManagedClasses()
     {
         ImmutableMap.Builder<String, ManagedClass> builder = ImmutableMap.builder();
-        for (Entry<ObjectName, ManagedClass> entry : exportedManagedClasses.entrySet()) {
-            builder.put(entry.getKey().toString(), entry.getValue());
+        for (Entry<ObjectName, ManagedObjectExport> entry : exportedManagedObjectExports.entrySet()) {
+            builder.put(entry.getKey().toString(), entry.getValue().getManagedClass());
         }
         return builder.build();
+    }
+
+    /**
+     * Returns metadata for managed objects exported through this exporter, keyed by final {@link ObjectName}.
+     */
+    public Map<ObjectName, ManagedObjectExport> getManagedObjectExports()
+    {
+        return ImmutableMap.copyOf(exportedManagedObjectExports);
     }
 
     public Optional<Object> getExportedObject(ObjectName objectName)

--- a/src/main/java/org/weakref/jmx/ManagedObjectExport.java
+++ b/src/main/java/org/weakref/jmx/ManagedObjectExport.java
@@ -1,0 +1,85 @@
+/**
+ *  Copyright 2009 Martin Traverso
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.weakref.jmx;
+
+import com.google.common.collect.ImmutableMap;
+
+import javax.management.ObjectName;
+
+import java.util.Map;
+import java.util.Optional;
+
+import static java.util.Objects.requireNonNull;
+
+/**
+ * Metadata for a managed object exported through an {@link MBeanExporter}.
+ */
+public final class ManagedObjectExport
+{
+    private final ObjectName objectName;
+    private final Optional<Class<?>> exportedType;
+    private final Optional<String> originalName;
+    private final Map<String, String> originalProperties;
+    private final ManagedClass managedClass;
+
+    ManagedObjectExport(
+            ObjectName objectName,
+            Optional<Class<?>> exportedType,
+            Optional<String> originalName,
+            Map<String, String> originalProperties,
+            ManagedClass managedClass)
+    {
+        this.objectName = requireNonNull(objectName, "objectName is null");
+        this.exportedType = requireNonNull(exportedType, "exportedType is null");
+        this.originalName = requireNonNull(originalName, "originalName is null");
+        this.originalProperties = ImmutableMap.copyOf(requireNonNull(originalProperties, "originalProperties is null"));
+        this.managedClass = requireNonNull(managedClass, "managedClass is null");
+    }
+
+    public ObjectName getObjectName()
+    {
+        return objectName;
+    }
+
+    /**
+     * Original Java type supplied when the object was exported, if one was available.
+     */
+    public Optional<Class<?>> getExportedType()
+    {
+        return exportedType;
+    }
+
+    /**
+     * Original name argument passed to the {@link ObjectNameGenerator}, if any.
+     */
+    public Optional<String> getOriginalName()
+    {
+        return originalName;
+    }
+
+    /**
+     * Original properties map passed to the {@link ObjectNameGenerator}, if any.
+     */
+    public Map<String, String> getOriginalProperties()
+    {
+        return originalProperties;
+    }
+
+    public ManagedClass getManagedClass()
+    {
+        return managedClass;
+    }
+}

--- a/src/main/java/org/weakref/jmx/guice/GuiceMBeanExporter.java
+++ b/src/main/java/org/weakref/jmx/guice/GuiceMBeanExporter.java
@@ -20,13 +20,9 @@ import com.google.inject.Injector;
 import org.weakref.jmx.MBeanExporter;
 import org.weakref.jmx.ObjectNameGenerator;
 
-import javax.management.ObjectName;
-
 import java.util.Map;
-import java.util.Map.Entry;
 import java.util.Optional;
 import java.util.Set;
-import java.util.function.BiFunction;
 
 class GuiceMBeanExporter
 {
@@ -61,13 +57,10 @@ class GuiceMBeanExporter
     private static <K, V> void exportMaps(Set<MapMapping<K, V>> mapMappings, MBeanExporter exporter, Injector injector, ObjectNameGenerator objectNameGenerator)
     {
         for (MapMapping<K, V> mapping : mapMappings) {
-            BiFunction<ObjectNameGenerator, Entry<K, V>, ObjectName> namingFunction = mapping.getObjectNameFunction();
-
             Map<K, V> map = injector.getInstance(mapping.getKey());
 
             for (Map.Entry<K, V> entry : map.entrySet()) {
-                ObjectName name = namingFunction.apply(objectNameGenerator, entry);
-                exporter.export(name, entry.getValue());
+                mapping.export(exporter, objectNameGenerator, entry);
             }
         }
     }
@@ -75,13 +68,10 @@ class GuiceMBeanExporter
     private static <T> void exportSets(Set<SetMapping<T>> setMappings, MBeanExporter exporter, Injector injector, ObjectNameGenerator objectNameGenerator)
     {
         for (SetMapping<T> mapping : setMappings) {
-            BiFunction<ObjectNameGenerator, T, ObjectName> namingFunction = mapping.getObjectNameFunction();
-
             Set<T> set = injector.getInstance(mapping.getKey());
 
             for (T instance : set) {
-                ObjectName name = namingFunction.apply(objectNameGenerator, instance);
-                exporter.export(name, instance);
+                mapping.export(exporter, objectNameGenerator, instance);
             }
         }
     }
@@ -89,7 +79,7 @@ class GuiceMBeanExporter
     private static void export(Set<Mapping> mappings, MBeanExporter exporter, Injector injector, ObjectNameGenerator objectNameGenerator)
     {
         for (Mapping mapping : mappings) {
-            exporter.export(mapping.getName(objectNameGenerator), injector.getInstance(mapping.getKey()));
+            mapping.export(exporter, objectNameGenerator, injector.getInstance(mapping.getKey()));
         }
     }
 }

--- a/src/main/java/org/weakref/jmx/guice/MapExportBinder.java
+++ b/src/main/java/org/weakref/jmx/guice/MapExportBinder.java
@@ -3,7 +3,6 @@ package org.weakref.jmx.guice;
 import com.google.inject.multibindings.Multibinder;
 import org.weakref.jmx.ObjectNameGenerator;
 
-import javax.management.MalformedObjectNameException;
 import javax.management.ObjectName;
 
 import java.util.Map.Entry;
@@ -24,17 +23,7 @@ public class MapExportBinder<K, V>
 
     public void withGeneratedName(NamingFunction<V> valueNamingFunction)
     {
-        BiFunction<ObjectNameGenerator, Entry<K, V>, ObjectName> nameFactory = (factory, entry) -> {
-            try {
-                String itemName = valueNamingFunction.name(entry.getValue());
-                return new ObjectName(factory.generatedNameOf(valueClass, itemName));
-            }
-            catch (MalformedObjectNameException e) {
-                throw new RuntimeException(e);
-            }
-        };
-
-        as(nameFactory);
+        binder.addBinding().toInstance(MapMapping.generatedName(keyClass, valueClass, (key, value) -> valueNamingFunction.name(value)));
     }
 
     public void withGeneratedName(ObjectNameFunction<V> valueNamingFunction)
@@ -44,17 +33,7 @@ public class MapExportBinder<K, V>
 
     public void withGeneratedName(MapNamingFunction<K, V> valueNamingFunction)
     {
-        BiFunction<ObjectNameGenerator, Entry<K, V>, ObjectName> nameFactory = (factory, entry) -> {
-            try {
-                String itemName = valueNamingFunction.name(entry.getKey(), entry.getValue());
-                return new ObjectName(factory.generatedNameOf(valueClass, itemName));
-            }
-            catch (MalformedObjectNameException e) {
-                throw new RuntimeException(e);
-            }
-        };
-
-        as(nameFactory);
+        binder.addBinding().toInstance(MapMapping.generatedName(keyClass, valueClass, valueNamingFunction));
     }
 
     public void withGeneratedName(MapObjectNameFunction<K, V> valueNamingFunction)

--- a/src/main/java/org/weakref/jmx/guice/MapMapping.java
+++ b/src/main/java/org/weakref/jmx/guice/MapMapping.java
@@ -1,6 +1,7 @@
 package org.weakref.jmx.guice;
 
 import com.google.inject.Key;
+import org.weakref.jmx.MBeanExporter;
 import org.weakref.jmx.ObjectNameGenerator;
 
 import javax.management.ObjectName;
@@ -13,25 +14,44 @@ import static com.google.inject.util.Types.mapOf;
 
 class MapMapping<K, V>
 {
-    private final BiFunction<ObjectNameGenerator, Entry<K, V>, ObjectName> objectNameFunction;
     private final Class<K> keyClass;
     private final Class<V> valueClass;
+    private final ExportAction<K, V> exportAction;
 
     MapMapping(Class<K> keyClass, Class<V> valueClass, BiFunction<ObjectNameGenerator, Entry<K, V>, ObjectName> objectNameFunction)
     {
-        this.keyClass = keyClass;
-        this.valueClass = valueClass;
-        this.objectNameFunction = objectNameFunction;
+        this(keyClass, valueClass, (exporter, objectNameGenerator, entry) -> exporter.export(objectNameFunction.apply(objectNameGenerator, entry), entry.getValue(), valueClass));
     }
 
-    public BiFunction<ObjectNameGenerator, Entry<K, V>, ObjectName> getObjectNameFunction()
+    private MapMapping(Class<K> keyClass, Class<V> valueClass, ExportAction<K, V> exportAction)
     {
-        return objectNameFunction;
+        this.keyClass = keyClass;
+        this.valueClass = valueClass;
+        this.exportAction = exportAction;
+    }
+
+    public static <K, V> MapMapping<K, V> generatedName(Class<K> keyClass, Class<V> valueClass, MapNamingFunction<K, V> namingFunction)
+    {
+        return new MapMapping<>(keyClass, valueClass, (exporter, objectNameGenerator, entry) -> {
+            String name = namingFunction.name(entry.getKey(), entry.getValue());
+            ObjectName objectName = Mapping.createObjectName(objectNameGenerator.generatedNameOf(valueClass, name));
+            exporter.exportWithGeneratedName(objectName, entry.getValue(), valueClass, name);
+        });
     }
 
     @SuppressWarnings("unchecked")
     public Key<Map<K, V>> getKey()
     {
         return (Key<Map<K, V>>) Key.get(mapOf(keyClass, valueClass));
+    }
+
+    public void export(MBeanExporter exporter, ObjectNameGenerator objectNameGenerator, Entry<K, V> entry)
+    {
+        exportAction.export(exporter, objectNameGenerator, entry);
+    }
+
+    private interface ExportAction<K, V>
+    {
+        void export(MBeanExporter exporter, ObjectNameGenerator objectNameGenerator, Entry<K, V> entry);
     }
 }

--- a/src/main/java/org/weakref/jmx/guice/Mapping.java
+++ b/src/main/java/org/weakref/jmx/guice/Mapping.java
@@ -16,28 +16,69 @@
 package org.weakref.jmx.guice;
 
 import com.google.inject.Key;
+import org.weakref.jmx.MBeanExporter;
 import org.weakref.jmx.ObjectNameGenerator;
 
+import javax.management.MalformedObjectNameException;
+import javax.management.ObjectName;
+
+import java.util.Optional;
 import java.util.function.Function;
 
 class Mapping
 {
-    private final Function<ObjectNameGenerator, String> nameFactory;
     private final Key<?> key;
+    private final ExportAction exportAction;
 
     Mapping(Function<ObjectNameGenerator, String> nameFactory, Key<?> key)
     {
-        this.nameFactory = nameFactory;
-        this.key = key;
+        this(key, (exporter, objectNameGenerator, object) -> exporter.export(nameFactory.apply(objectNameGenerator), object, key.getTypeLiteral().getRawType()));
     }
 
-    public String getName(ObjectNameGenerator objectNameGenerator)
+    private Mapping(Key<?> key, ExportAction exportAction)
     {
-        return nameFactory.apply(objectNameGenerator);
+        this.key = key;
+        this.exportAction = exportAction;
+    }
+
+    public static Mapping generatedName(Key<?> key, Optional<String> generatedName)
+    {
+        return new Mapping(key, (exporter, objectNameGenerator, object) -> {
+            Class<?> type = key.getTypeLiteral().getRawType();
+            if (generatedName.isPresent()) {
+                String name = generatedName.get();
+                ObjectName objectName = createObjectName(objectNameGenerator.generatedNameOf(type, name));
+                exporter.exportWithGeneratedName(objectName, object, type, name);
+            }
+            else {
+                ObjectName objectName = createObjectName(objectNameGenerator.generatedNameOf(type));
+                exporter.exportWithGeneratedName(objectName, object, type);
+            }
+        });
     }
 
     public Key<?> getKey()
     {
         return key;
+    }
+
+    public void export(MBeanExporter exporter, ObjectNameGenerator objectNameGenerator, Object object)
+    {
+        exportAction.export(exporter, objectNameGenerator, object);
+    }
+
+    private interface ExportAction
+    {
+        void export(MBeanExporter exporter, ObjectNameGenerator objectNameGenerator, Object object);
+    }
+
+    static ObjectName createObjectName(String name)
+    {
+        try {
+            return new ObjectName(name);
+        }
+        catch (MalformedObjectNameException e) {
+            throw new RuntimeException(e);
+        }
     }
 }

--- a/src/main/java/org/weakref/jmx/guice/NamedExportBinder.java
+++ b/src/main/java/org/weakref/jmx/guice/NamedExportBinder.java
@@ -20,6 +20,7 @@ import com.google.inject.multibindings.Multibinder;
 import com.google.inject.name.Named;
 import org.weakref.jmx.ObjectNameGenerator;
 
+import java.util.Optional;
 import java.util.function.Function;
 
 public class NamedExportBinder
@@ -40,17 +41,17 @@ public class NamedExportBinder
     {
         if (key.getAnnotation() != null) {
             if (key.getAnnotation() instanceof Named annotation) {
-                as(factory -> factory.generatedNameOf(key.getTypeLiteral().getRawType(), annotation.value()));
+                asGeneratedName(annotation.value());
             }
             else {
-                as(factory -> factory.generatedNameOf(key.getTypeLiteral().getRawType(), key.getAnnotation().annotationType().getSimpleName()));
+                asGeneratedName(key.getAnnotation().annotationType().getSimpleName());
             }
         }
         else if (key.getAnnotationType() != null) {
-            as(factory -> factory.generatedNameOf(key.getTypeLiteral().getRawType(), key.getAnnotationType().getSimpleName()));
+            asGeneratedName(key.getAnnotationType().getSimpleName());
         }
         else {
-            as(factory -> factory.generatedNameOf(key.getTypeLiteral().getRawType()));
+            binder.addBinding().toInstance(Mapping.generatedName(key, Optional.empty()));
         }
     }
 
@@ -62,5 +63,10 @@ public class NamedExportBinder
     public void as(Function<ObjectNameGenerator, String> nameFactory)
     {
         binder.addBinding().toInstance(new Mapping(nameFactory, key));
+    }
+
+    private void asGeneratedName(String name)
+    {
+        binder.addBinding().toInstance(Mapping.generatedName(key, Optional.of(name)));
     }
 }

--- a/src/main/java/org/weakref/jmx/guice/SetExportBinder.java
+++ b/src/main/java/org/weakref/jmx/guice/SetExportBinder.java
@@ -3,7 +3,6 @@ package org.weakref.jmx.guice;
 import com.google.inject.multibindings.Multibinder;
 import org.weakref.jmx.ObjectNameGenerator;
 
-import javax.management.MalformedObjectNameException;
 import javax.management.ObjectName;
 
 import java.util.function.BiFunction;
@@ -21,17 +20,7 @@ public class SetExportBinder<T>
 
     public void withGeneratedName(final NamingFunction<T> itemNamingFunction)
     {
-        BiFunction<ObjectNameGenerator, T, ObjectName> nameFactory = (factory, object) -> {
-            try {
-                String itemName = itemNamingFunction.name(object);
-                return new ObjectName(factory.generatedNameOf(clazz, itemName));
-            }
-            catch (MalformedObjectNameException e) {
-                throw new RuntimeException(e);
-            }
-        };
-
-        as(nameFactory);
+        binder.addBinding().toInstance(SetMapping.generatedName(clazz, itemNamingFunction));
     }
 
     public void withGeneratedName(final ObjectNameFunction<T> itemNamingFunction)

--- a/src/main/java/org/weakref/jmx/guice/SetMapping.java
+++ b/src/main/java/org/weakref/jmx/guice/SetMapping.java
@@ -1,6 +1,7 @@
 package org.weakref.jmx.guice;
 
 import com.google.inject.Key;
+import org.weakref.jmx.MBeanExporter;
 import org.weakref.jmx.ObjectNameGenerator;
 
 import javax.management.ObjectName;
@@ -12,23 +13,42 @@ import static com.google.inject.util.Types.setOf;
 
 class SetMapping<T>
 {
-    private final BiFunction<ObjectNameGenerator, T, ObjectName> objectNameFunction;
     private final Class<T> clazz;
+    private final ExportAction<T> exportAction;
 
     SetMapping(Class<T> key, BiFunction<ObjectNameGenerator, T, ObjectName> objectNameFunction)
     {
-        this.clazz = key;
-        this.objectNameFunction = objectNameFunction;
+        this(key, (exporter, objectNameGenerator, object) -> exporter.export(objectNameFunction.apply(objectNameGenerator, object), object, key));
     }
 
-    public BiFunction<ObjectNameGenerator, T, ObjectName> getObjectNameFunction()
+    private SetMapping(Class<T> key, ExportAction<T> exportAction)
     {
-        return objectNameFunction;
+        this.clazz = key;
+        this.exportAction = exportAction;
+    }
+
+    public static <T> SetMapping<T> generatedName(Class<T> key, NamingFunction<T> namingFunction)
+    {
+        return new SetMapping<>(key, (exporter, objectNameGenerator, object) -> {
+            String name = namingFunction.name(object);
+            ObjectName objectName = Mapping.createObjectName(objectNameGenerator.generatedNameOf(key, name));
+            exporter.exportWithGeneratedName(objectName, object, key, name);
+        });
     }
 
     @SuppressWarnings("unchecked")
     public Key<Set<T>> getKey()
     {
         return (Key<Set<T>>) Key.get(setOf(clazz));
+    }
+
+    public void export(MBeanExporter exporter, ObjectNameGenerator objectNameGenerator, T object)
+    {
+        exportAction.export(exporter, objectNameGenerator, object);
+    }
+
+    private interface ExportAction<T>
+    {
+        void export(MBeanExporter exporter, ObjectNameGenerator objectNameGenerator, T object);
     }
 }

--- a/src/main/java/org/weakref/jmx/guice/StringMapExportBinder.java
+++ b/src/main/java/org/weakref/jmx/guice/StringMapExportBinder.java
@@ -1,13 +1,6 @@
 package org.weakref.jmx.guice;
 
 import com.google.inject.multibindings.Multibinder;
-import org.weakref.jmx.ObjectNameGenerator;
-
-import javax.management.MalformedObjectNameException;
-import javax.management.ObjectName;
-
-import java.util.Map.Entry;
-import java.util.function.BiFunction;
 
 public class StringMapExportBinder<V>
     extends MapExportBinder<String, V>
@@ -22,15 +15,6 @@ public class StringMapExportBinder<V>
 
     public void withGeneratedName()
     {
-        BiFunction<ObjectNameGenerator, Entry<String, V>, ObjectName> nameFactory = (factory, entry) -> {
-            try {
-                return new ObjectName(factory.generatedNameOf(valueClass, entry.getKey()));
-            }
-            catch (MalformedObjectNameException e) {
-                throw new RuntimeException(e);
-            }
-        };
-
-        as(nameFactory);
+        binder.addBinding().toInstance(MapMapping.generatedName(keyClass, valueClass, (key, value) -> key));
     }
 }

--- a/src/test/java/org/weakref/jmx/TestExporter.java
+++ b/src/test/java/org/weakref/jmx/TestExporter.java
@@ -31,6 +31,7 @@ import javax.management.ObjectName;
 import javax.management.ReflectionException;
 
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -129,6 +130,79 @@ public class TestExporter extends AbstractMbeanTest<TestExporter.NamedObject>
                 assertThat(managedClass.getChildren().get("SimpleObject").getTargetClass()).isEqualTo(SimpleObject.class);
             }
         }
+    }
+
+    @Test
+    void testManagedObjectExportsForManualExports()
+    {
+        Map<ObjectName, ManagedObjectExport> managedObjectExports = exporter.getManagedObjectExports();
+        for (NamedObject namedObject : objects) {
+            ManagedObjectExport managedObjectExport = managedObjectExports.get(namedObject.objectName);
+
+            assertThat(managedObjectExport).isNotNull();
+            assertThat(managedObjectExport.getObjectName()).isEqualTo(namedObject.objectName);
+            assertThat(managedObjectExport.getExportedType()).isEmpty();
+            assertThat(managedObjectExport.getOriginalName()).isEmpty();
+            assertThat(managedObjectExport.getOriginalProperties()).isEmpty();
+            assertThat(managedObjectExport.getManagedClass().getTarget()).isEqualTo(namedObject.object);
+        }
+    }
+
+    @Test
+    void testManagedObjectExportsForTypedManualExports()
+    {
+        MBeanExporter exporter = new MBeanExporter(server);
+        ObjectName objectName = getUniqueObjectName();
+        SimpleObject object = new SimpleObject();
+
+        exporter.export(objectName, object, TestExporter.class);
+
+        ManagedObjectExport managedObjectExport = exporter.getManagedObjectExports().get(objectName);
+        assertThat(managedObjectExport.getObjectName()).isEqualTo(objectName);
+        assertThat(managedObjectExport.getExportedType()).contains(TestExporter.class);
+        assertThat(managedObjectExport.getOriginalName()).isEmpty();
+        assertThat(managedObjectExport.getOriginalProperties()).isEmpty();
+        assertThat(managedObjectExport.getManagedClass().getTarget()).isEqualTo(object);
+    }
+
+    @Test
+    void testManagedObjectExportsForGeneratedNames()
+    {
+        MBeanExporter exporter = new MBeanExporter(server);
+
+        SimpleObject defaultObject = new SimpleObject();
+        MBeanExport defaultExport = exporter.exportWithGeneratedName(defaultObject, SimpleObject.class);
+        ManagedObjectExport defaultManagedObjectExport = exporter.getManagedObjectExports().get(defaultExport.getObjectName());
+        assertThat(defaultManagedObjectExport.getObjectName()).isEqualTo(defaultExport.getObjectName());
+        assertThat(defaultManagedObjectExport.getExportedType()).contains(SimpleObject.class);
+        assertThat(defaultManagedObjectExport.getOriginalName()).isEmpty();
+        assertThat(defaultManagedObjectExport.getOriginalProperties()).isEmpty();
+        assertThat(defaultManagedObjectExport.getManagedClass().getTarget()).isEqualTo(defaultObject);
+
+        SimpleObject namedObject = new SimpleObject();
+        MBeanExport namedExport = exporter.exportWithGeneratedName(namedObject, TestExporter.class, "queued");
+        ManagedObjectExport namedManagedObjectExport = exporter.getManagedObjectExports().get(namedExport.getObjectName());
+        assertThat(namedManagedObjectExport.getObjectName()).isEqualTo(namedExport.getObjectName());
+        assertThat(namedManagedObjectExport.getExportedType()).contains(TestExporter.class);
+        assertThat(namedManagedObjectExport.getOriginalName()).contains("queued");
+        assertThat(namedManagedObjectExport.getOriginalProperties()).isEmpty();
+        assertThat(namedManagedObjectExport.getManagedClass().getTarget()).isEqualTo(namedObject);
+
+        Map<String, String> properties = new HashMap<>();
+        properties.put("segment", "x");
+        SimpleObject propertyObject = new SimpleObject();
+        MBeanExport propertyExport = exporter.exportWithGeneratedName(propertyObject, TestExporter.class, properties);
+        properties.put("segment", "changed");
+
+        ManagedObjectExport propertyManagedObjectExport = exporter.getManagedObjectExports().get(propertyExport.getObjectName());
+        assertThat(propertyManagedObjectExport.getObjectName()).isEqualTo(propertyExport.getObjectName());
+        assertThat(propertyManagedObjectExport.getExportedType()).contains(TestExporter.class);
+        assertThat(propertyManagedObjectExport.getOriginalName()).isEmpty();
+        assertThat(propertyManagedObjectExport.getOriginalProperties()).containsExactly(Map.entry("segment", "x"));
+        assertThat(propertyManagedObjectExport.getManagedClass().getTarget()).isEqualTo(propertyObject);
+
+        namedExport.unexport();
+        assertThat(exporter.getManagedObjectExports()).doesNotContainKey(namedExport.getObjectName());
     }
 
     @Test

--- a/src/test/java/org/weakref/jmx/guice/TestMBeanModule.java
+++ b/src/test/java/org/weakref/jmx/guice/TestMBeanModule.java
@@ -21,13 +21,15 @@ import com.google.inject.Injector;
 import com.google.inject.Key;
 import com.google.inject.Module;
 import com.google.inject.multibindings.Multibinder;
+import com.google.inject.util.Modules;
 import org.junit.jupiter.api.Test;
-import static org.assertj.core.api.Assertions.assertThat;
+import org.weakref.jmx.ManagedObjectExport;
 import org.weakref.jmx.MBeanExporter;
 import org.weakref.jmx.ObjectNameBuilder;
 import org.weakref.jmx.ObjectNameGenerator;
 import org.weakref.jmx.SimpleObject;
 import org.weakref.jmx.Util;
+import org.weakref.jmx.testing.TestingMBeanServer;
 
 import javax.management.InstanceNotFoundException;
 import javax.management.IntrospectionException;
@@ -38,9 +40,12 @@ import javax.management.ReflectionException;
 
 import java.lang.management.ManagementFactory;
 import java.util.Map;
+import java.util.Optional;
 
 import static com.google.inject.Stage.PRODUCTION;
 import static com.google.inject.name.Names.named;
+import static com.google.inject.multibindings.OptionalBinder.newOptionalBinder;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.weakref.jmx.ObjectNames.generatedNameOf;
 
 public class TestMBeanModule
@@ -92,6 +97,11 @@ public class TestMBeanModule
         MBeanServer server = injector.getInstance(MBeanServer.class);
 
         assertThat(server.getMBeanInfo(name)).isNotNull();
+        ManagedObjectExport managedObjectExport = injector.getInstance(MBeanExporter.class).getManagedObjectExports().get(name);
+        assertThat(managedObjectExport.getObjectName()).isEqualTo(name);
+        assertThat(managedObjectExport.getExportedType()).contains(SimpleObject.class);
+        assertThat(managedObjectExport.getOriginalName()).isEmpty();
+        assertThat(managedObjectExport.getOriginalProperties()).isEmpty();
         server.unregisterMBean(name);
     }
 
@@ -131,6 +141,42 @@ public class TestMBeanModule
         MBeanServer server = injector.getInstance(MBeanServer.class);
 
         assertThat(server.getMBeanInfo(name)).isNotNull();
+        ManagedObjectExport managedObjectExport = injector.getInstance(MBeanExporter.class).getManagedObjectExports().get(name);
+        assertThat(managedObjectExport.getObjectName()).isEqualTo(name);
+        assertThat(managedObjectExport.getExportedType()).contains(SimpleObject.class);
+        assertThat(managedObjectExport.getOriginalName()).isEmpty();
+        assertThat(managedObjectExport.getOriginalProperties()).isEmpty();
+        server.unregisterMBean(name);
+    }
+
+    @Test
+    public void testGeneratedNameOnAnnotationClassMetadata()
+            throws Exception
+    {
+        ObjectName name = new ObjectName(generatedNameOf(SimpleObject.class, TestAnnotation.class));
+
+        Injector injector = Guice.createInjector(PRODUCTION, new MBeanModule(), new AbstractModule()
+        {
+            @Override
+            protected void configure()
+            {
+                binder().requireExplicitBindings();
+                binder().disableCircularProxies();
+
+                bind(SimpleObject.class).annotatedWith(TestAnnotation.class).toInstance(new SimpleObject());
+                bind(MBeanServer.class).toInstance(ManagementFactory.getPlatformMBeanServer());
+                ExportBinder.newExporter(binder()).export(SimpleObject.class).annotatedWith(TestAnnotation.class).withGeneratedName();
+            }
+        });
+
+        MBeanServer server = injector.getInstance(MBeanServer.class);
+
+        assertThat(server.getMBeanInfo(name)).isNotNull();
+        ManagedObjectExport managedObjectExport = injector.getInstance(MBeanExporter.class).getManagedObjectExports().get(name);
+        assertThat(managedObjectExport.getObjectName()).isEqualTo(name);
+        assertThat(managedObjectExport.getExportedType()).contains(SimpleObject.class);
+        assertThat(managedObjectExport.getOriginalName()).contains(TestAnnotation.class.getSimpleName());
+        assertThat(managedObjectExport.getOriginalProperties()).isEmpty();
         server.unregisterMBean(name);
     }
 
@@ -170,7 +216,51 @@ public class TestMBeanModule
         MBeanServer server = injector.getInstance(MBeanServer.class);
 
         assertThat(server.getMBeanInfo(name)).isNotNull();
+        ManagedObjectExport managedObjectExport = injector.getInstance(MBeanExporter.class).getManagedObjectExports().get(name);
+        assertThat(managedObjectExport.getObjectName()).isEqualTo(name);
+        assertThat(managedObjectExport.getExportedType()).contains(SimpleObject.class);
+        assertThat(managedObjectExport.getOriginalName()).contains("hello");
+        assertThat(managedObjectExport.getOriginalProperties()).isEmpty();
         server.unregisterMBean(name);
+    }
+
+    @Test
+    public void testGeneratedNameUsesConfiguredGenerator()
+            throws Exception
+    {
+        MBeanServer server = new TestingMBeanServer();
+        ObjectNameGenerator configuredGenerator = new DomainObjectNameGenerator("from.binding");
+        ObjectNameGenerator exporterGenerator = new DomainObjectNameGenerator("from.exporter");
+
+        Injector injector = Guice.createInjector(PRODUCTION,
+                Modules.override(new MBeanModule()).with(new AbstractModule()
+                {
+                    @Override
+                    protected void configure()
+                    {
+                        binder().requireExplicitBindings();
+                        binder().disableCircularProxies();
+
+                        bind(MBeanServer.class).toInstance(server);
+                        newOptionalBinder(binder(), ObjectNameGenerator.class).setBinding().toInstance(configuredGenerator);
+                        bind(MBeanExporter.class).toInstance(new MBeanExporter(server, Optional.of(exporterGenerator)));
+                        bind(SimpleObject.class).annotatedWith(named("generated")).toInstance(new SimpleObject());
+                        bind(SimpleObject.class).annotatedWith(named("custom")).toInstance(new SimpleObject());
+
+                        ExportBinder exporter = ExportBinder.newExporter(binder());
+                        exporter.export(SimpleObject.class).annotatedWith(named("generated")).withGeneratedName();
+                        exporter.export(SimpleObject.class).annotatedWith(named("custom")).as(generator -> generator.generatedNameOf(SimpleObject.class, "custom"));
+                    }
+                }));
+
+        ObjectName generatedName = new ObjectName("from.binding:type=SimpleObject,name=generated");
+        ObjectName customName = new ObjectName("from.binding:type=SimpleObject,name=custom");
+        ObjectName generatedNameFromExporter = new ObjectName("from.exporter:type=SimpleObject,name=generated");
+
+        Map<ObjectName, ManagedObjectExport> exports = injector.getInstance(MBeanExporter.class).getManagedObjectExports();
+        assertThat(exports).containsKeys(generatedName, customName);
+        assertThat(exports).doesNotContainKey(generatedNameFromExporter);
+        assertThat(exports.get(generatedName).getOriginalName()).contains("generated");
     }
 
     @Test
@@ -347,6 +437,18 @@ public class TestMBeanModule
         public String generatedNameOf(Class<?> type, Map<String, String> properties)
         {
             return new ObjectNameBuilder("test")
+                    .withProperties(properties)
+                    .build();
+        }
+    }
+
+    private record DomainObjectNameGenerator(String domain)
+            implements ObjectNameGenerator
+    {
+        @Override
+        public String generatedNameOf(Class<?> type, Map<String, String> properties)
+        {
+            return new ObjectNameBuilder(domain)
                     .withProperties(properties)
                     .build();
         }


### PR DESCRIPTION
## Why
- Systems such as OpenMetrics and OpenTelemetry have their own metric naming conventions and need the original export intent to build useful names.
- Today, jmxutils collapses the Java type and generated-name inputs into a final `ObjectName`, which forces consumers to reverse-engineer naming intent from JMX properties.
- Consumers still need the final `ObjectName` because configured generators may rewrite domains or add identity properties used as labels.

## Approach
- Add a managed export descriptor keyed by final `ObjectName`.
- Retain the original Java type, generated-name argument, generated-properties map, and associated `ManagedClass` when available.
- Keep the existing `getManagedClasses()` API as a compatibility projection.